### PR TITLE
Refactor augmentation dataset handling

### DIFF
--- a/code/v6_augment/data.py
+++ b/code/v6_augment/data.py
@@ -120,6 +120,28 @@ class AugmentedDataset(Dataset):
         return image, target, base_idx
 
 
+def _build_augmented_dataset(
+    df: pd.DataFrame,
+    path: str,
+    transform,
+    org_transform,
+    aug_count: int,
+    add_org: bool,
+) -> Dataset:
+    """Create dataset with optional augmentation."""
+
+    base_ds = IndexedImageDataset(df, path, transform=None)
+    if aug_count > 0:
+        return AugmentedDataset(
+            base_ds,
+            aug_count,
+            add_org,
+            aug_transform=transform,
+            org_transform=org_transform,
+        )
+    return IndexedImageDataset(df, path, transform=transform)
+
+
 def _create_augraphy_lambda(intensity: float, ops: list[str] | None = None):
     """Create an Albumentations Lambda applying selected Augraphy transforms."""
     try:
@@ -374,7 +396,7 @@ def prepare_data_loaders(cfg, seed):
             train_transform,
             val_transform,
             seed,
-            org_transform
+            org_transform,
         )
         return train_loader, val_loader, test_loader, None
         
@@ -390,34 +412,22 @@ def prepare_data_loaders(cfg, seed):
         )
         
     elif validation_strategy == "none":
-        train_dataset = IndexedImageDataset(
+        train_dataset = _build_augmented_dataset(
             full_train_df,
             train_images_path,
-            transform=None  # transform 없이 생성
+            train_transform,
+            org_transform,
+            getattr(aug_cfg, "train_aug_count", 0),
+            getattr(aug_cfg, "train_aug_add_org", False),
         )
-        if getattr(aug_cfg, "train_aug_count", 0) > 0:
-            train_dataset = AugmentedDataset(
-                train_dataset,
-                getattr(aug_cfg, "train_aug_count", 0),
-                getattr(aug_cfg, "train_aug_add_org", False),
-                aug_transform=train_transform,  # 증강 transform
-                org_transform=org_transform     # 원본 transform
-            )
-        else:
-            # 증강이 없는 경우 기본 transform 적용
-            train_dataset = IndexedImageDataset(
-                full_train_df,
-                train_images_path,
-                transform=train_transform
-            )
 
         train_loader = DataLoader(
             train_dataset,
             batch_size=batch_size,
             shuffle=True,
             num_workers=num_workers,
-            pin_memory=_should_use_pin_memory(), 
-            drop_last=False
+            pin_memory=_should_use_pin_memory(),
+            drop_last=False,
         )
         return train_loader, None, test_loader, None
         
@@ -450,47 +460,23 @@ def _prepare_holdout_loaders(cfg, full_train_df, train_images_path,
         )
     
     # Dataset 정의
-    train_dataset = IndexedImageDataset(
+    train_dataset = _build_augmented_dataset(
         train_df,
         train_images_path,
-        transform=None  # transform 없이 생성
+        train_transform,
+        org_transform,
+        getattr(aug_cfg, "train_aug_count", 0),
+        getattr(aug_cfg, "train_aug_add_org", False),
     )
-    if getattr(aug_cfg, "train_aug_count", 0) > 0:
-        train_dataset = AugmentedDataset(
-            train_dataset,
-            getattr(aug_cfg, "train_aug_count", 0),
-            getattr(aug_cfg, "train_aug_add_org", False),
-            aug_transform=train_transform,  # 증강 transform
-            org_transform=org_transform     # 원본 transform
-        )
-    else:
-        # 증강이 없는 경우 기본 transform 적용
-        train_dataset = IndexedImageDataset(
-            train_df,
-            train_images_path,
-            transform=train_transform
-        )
 
-    val_dataset = IndexedImageDataset(
+    val_dataset = _build_augmented_dataset(
         val_df,
         train_images_path,
-        transform=None  # transform 없이 생성
+        val_transform,
+        org_transform,
+        getattr(aug_cfg, "valid_aug_count", 0),
+        getattr(aug_cfg, "valid_aug_add_org", False),
     )
-    if getattr(aug_cfg, "valid_aug_count", 0) > 0:
-        val_dataset = AugmentedDataset(
-            val_dataset,
-            getattr(aug_cfg, "valid_aug_count", 0),
-            getattr(aug_cfg, "valid_aug_add_org", False),
-            aug_transform=val_transform,    # 증강 transform
-            org_transform=org_transform     # 원본 transform
-        )
-    else:
-        # 증강이 없는 경우 기본 transform 적용
-        val_dataset = IndexedImageDataset(
-            val_df,
-            train_images_path,
-            transform=val_transform
-        )
     
     # DataLoader 정의
     train_loader = DataLoader(
@@ -543,47 +529,23 @@ def get_kfold_loaders(fold_idx, folds, full_train_df, train_images_path,
     val_df = full_train_df.iloc[val_idx]
     
     # Dataset 정의
-    train_dataset = IndexedImageDataset(
+    train_dataset = _build_augmented_dataset(
         train_df,
         train_images_path,
-        transform=None  # transform 없이 생성
+        train_transform,
+        org_transform,
+        getattr(aug_cfg, "train_aug_count", 0),
+        getattr(aug_cfg, "train_aug_add_org", False),
     )
-    if getattr(aug_cfg, "train_aug_count", 0) > 0:
-        train_dataset = AugmentedDataset(
-            train_dataset,
-            getattr(aug_cfg, "train_aug_count", 0),
-            getattr(aug_cfg, "train_aug_add_org", False),
-            aug_transform=train_transform,  # 증강 transform
-            org_transform=org_transform     # 원본 transform
-        )
-    else:
-        # 증강이 없는 경우 기본 transform 적용
-        train_dataset = IndexedImageDataset(
-            train_df,
-            train_images_path,
-            transform=train_transform
-        )
 
-    val_dataset = IndexedImageDataset(
+    val_dataset = _build_augmented_dataset(
         val_df,
         train_images_path,
-        transform=None  # transform 없이 생성
+        val_transform,
+        org_transform,
+        getattr(aug_cfg, "valid_aug_count", 0),
+        getattr(aug_cfg, "valid_aug_add_org", False),
     )
-    if getattr(aug_cfg, "valid_aug_count", 0) > 0:
-        val_dataset = AugmentedDataset(
-            val_dataset,
-            getattr(aug_cfg, "valid_aug_count", 0),
-            getattr(aug_cfg, "valid_aug_add_org", False),
-            aug_transform=val_transform,    # 증강 transform
-            org_transform=org_transform     # 원본 transform
-        )
-    else:
-        # 증강이 없는 경우 기본 transform 적용
-        val_dataset = IndexedImageDataset(
-            val_df,
-            train_images_path,
-            transform=val_transform
-        )
     
     # DataLoader 정의
     train_loader = DataLoader(

--- a/code/v6_augment/inference.py
+++ b/code/v6_augment/inference.py
@@ -55,7 +55,10 @@ def predict_single_model(model, test_loader, device, tta_transform=None, tta_cou
 
     model.eval()
 
-    probs = _predict_probs(model, test_loader, device)
+    probs = None
+    run_base = tta_transform is None or tta_count == 0 or tta_add_org
+    if run_base:
+        probs = _predict_probs(model, test_loader, device)
 
     if tta_transform is not None and tta_count > 0:
         tta_probs = []
@@ -68,15 +71,12 @@ def predict_single_model(model, test_loader, device, tta_transform=None, tta_cou
                 num_workers=test_loader.num_workers,
             )
             tta_probs.append(_predict_probs(model, t_loader, device))
-        
-        # TTA 결과 평균 계산
+
         tta_avg = np.mean(tta_probs, axis=0)
-        
+
         if tta_add_org:
-            # 원본 이미지 포함하여 평균
             probs = (probs + tta_avg * tta_count) / (tta_count + 1)
         else:
-            # 원본 이미지 제외하고 TTA 결과만 사용
             probs = tta_avg
 
     if return_probs:
@@ -107,7 +107,8 @@ def predict_kfold_ensemble(models, test_loader, device, tta_transform=None, tta_
         
         model.eval()
 
-        probs = _predict_probs(model, test_loader, device)
+        run_base = tta_transform is None or tta_count == 0 or tta_add_org
+        probs = _predict_probs(model, test_loader, device) if run_base else None
 
         if tta_transform is not None and tta_count > 0:
             tta_probs = []
@@ -121,14 +122,11 @@ def predict_kfold_ensemble(models, test_loader, device, tta_transform=None, tta_
                 )
                 tta_probs.append(_predict_probs(model, t_loader, device))
             
-            # TTA 결과 평균 계산
             tta_avg = np.mean(tta_probs, axis=0)
-            
+
             if tta_add_org:
-                # 원본 이미지 포함하여 평균
                 probs = (probs + tta_avg * tta_count) / (tta_count + 1)
             else:
-                # 원본 이미지 제외하고 TTA 결과만 사용
                 probs = tta_avg
 
         fold_predictions = probs

--- a/code/v6_augment/tests/test_augmentation.py
+++ b/code/v6_augment/tests/test_augmentation.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from data import ImageDataset, AugmentedDataset, get_transforms
 from inference import predict_single_model
+from unittest.mock import patch
 import pytest
 
 
@@ -110,6 +111,27 @@ def test_predict_single_model_tta_add_org():
     
     assert len(preds_with_org) == len(dataset)
     assert len(preds_without_org) == len(dataset)
+
+
+@patch('inference._predict_probs')
+def test_skip_original_when_tta_no_org(mock_pred):
+    """tta_add_org=False일 때 base 추론이 생략되는지 테스트"""
+    tmp = tempfile.mkdtemp()
+    img_dir = os.path.join(tmp, 'imgs')
+    os.makedirs(img_dir)
+    df = pd.DataFrame({'ID': [f'{i}.jpg' for i in range(2)], 'target': [0, 1]})
+    for name in df['ID']:
+        Image.new('RGB', (32, 32), color='white').save(os.path.join(img_dir, name))
+    cfg = OmegaConf.create({'data': {'img_size': 32}, 'augmentation': {'method': 'albumentations', 'intensity': 0.5, 'test_tta_ops': ['rotate']}})
+    tta_transform = get_transforms(cfg, 'test_tta_ops')
+    test_transform = get_transforms(cfg, None)
+    dataset = ImageDataset(df, img_dir, transform=test_transform)
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+    model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(32*32*3, 2))
+
+    mock_pred.return_value = np.zeros((len(dataset), 2))
+    predict_single_model(model, loader, torch.device('cpu'), tta_transform=tta_transform, tta_count=2, tta_add_org=False)
+    assert mock_pred.call_count == 2
 
 
 def test_get_transforms_many_ops():

--- a/code/v6_augment/tests/test_data.py
+++ b/code/v6_augment/tests/test_data.py
@@ -387,5 +387,69 @@ class TestKFoldLoaders:
         assert len(val_loader.dataset) == len(val_df)  # type: ignore
 
 
+class TestDataLoaderAugmentation:
+    """Augmentation 옵션에 따른 데이터셋 크기 테스트"""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.data_dir = os.path.join(self.temp_dir, "data")
+        os.makedirs(os.path.join(self.data_dir, "train"))
+        os.makedirs(os.path.join(self.data_dir, "test"))
+
+        n_train = 20
+        train_data = {
+            "ID": [f"train_{i}.jpg" for i in range(n_train)],
+            "target": [i % 2 for i in range(n_train)],
+        }
+        train_df = pd.DataFrame(train_data)
+        train_df.to_csv(os.path.join(self.data_dir, "train.csv"), index=False)
+
+        n_test = 10
+        test_data = {"ID": [f"test_{i}.jpg" for i in range(n_test)], "target": [0] * n_test}
+        pd.DataFrame(test_data).to_csv(
+            os.path.join(self.data_dir, "sample_submission.csv"), index=False
+        )
+
+        for img_name in train_data["ID"]:
+            Image.new("RGB", (32, 32), color="red").save(
+                os.path.join(self.data_dir, "train", img_name)
+            )
+        for img_name in test_data["ID"]:
+            Image.new("RGB", (32, 32), color="blue").save(
+                os.path.join(self.data_dir, "test", img_name)
+            )
+
+    def test_dataset_length_with_options(self):
+        cfg = OmegaConf.create(
+            {
+                "data": {
+                    "train_images_path": os.path.join(self.data_dir, "train"),
+                    "test_images_path": os.path.join(self.data_dir, "test"),
+                    "train_csv_path": os.path.join(self.data_dir, "train.csv"),
+                    "test_csv_path": os.path.join(self.data_dir, "sample_submission.csv"),
+                    "img_size": 32,
+                    "num_workers": 0,
+                },
+                "training": {"batch_size": 4, "seed": 42},
+                "validation": {
+                    "strategy": "holdout",
+                    "holdout": {"train_ratio": 0.8, "stratify": True},
+                },
+                "augmentation": {
+                    "method": "albumentations",
+                    "intensity": 0.0,
+                    "train_aug_count": 2,
+                    "train_aug_add_org": True,
+                    "valid_aug_count": 1,
+                    "valid_aug_add_org": False,
+                },
+            }
+        )
+
+        train_loader, val_loader, _, _ = prepare_data_loaders(cfg, 42)
+        # 80% of 20 = 16
+        assert len(train_loader.dataset) == 16 * 3  # 2 aug + original
+        assert len(val_loader.dataset) == 4 * 1  # 1 aug only
+
 if __name__ == "__main__":
     pytest.main([__file__]) 


### PR DESCRIPTION
## Summary
- restructure dataset loading with helper
- optimize TTA inference to avoid redundant base pass
- add tests for augmentation dataset length and TTA skip logic

## Testing
- `uv run -m pytest -q`
- `uv run main.py`

------
https://chatgpt.com/codex/tasks/task_e_686b1d5bffac8323928198bd4e102f57