### PR TITLE
Add augmentation caching system

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -110,10 +110,11 @@ class CachedAugmentedDataset(AugmentedDataset):
         base_transform: A.Compose,
         cache_root: str,
         seed: int,
+        img_size: int,
         prefix: str = "aug",
     ):
         super().__init__(base_dataset, num_aug, aug_transform, base_transform)
-        self.cache_dir = os.path.join(cache_root, f"seed_{seed}")
+        self.cache_dir = os.path.join(cache_root, f"img{img_size}_seed{seed}")
         os.makedirs(self.cache_dir, exist_ok=True)
         self.prefix = prefix
 
@@ -150,10 +151,10 @@ class CachedAugmentedDataset(AugmentedDataset):
 class CachedTransformDataset(Dataset):
     """Dataset wrapper applying transform with disk caching."""
 
-    def __init__(self, base_dataset: Dataset, transform: A.Compose, cache_root: str, seed: int, tta_idx: int = 1):
+    def __init__(self, base_dataset: Dataset, transform: A.Compose, cache_root: str, seed: int, img_size: int, tta_idx: int = 1):
         self.base_dataset = base_dataset
         self.transform = transform
-        self.cache_dir = os.path.join(cache_root, f"seed_{seed}")
+        self.cache_dir = os.path.join(cache_root, f"img{img_size}_seed{seed}")
         os.makedirs(self.cache_dir, exist_ok=True)
         self.tta_idx = tta_idx
 
@@ -269,6 +270,7 @@ def prepare_data_loaders(cfg, seed: int):
                 test_t,
                 cache_root,
                 seed,
+                cfg.data.img_size,
                 prefix="aug",
             )
         else:
@@ -281,6 +283,7 @@ def prepare_data_loaders(cfg, seed: int):
                 test_t,
                 cache_root,
                 seed,
+                cfg.data.img_size,
                 prefix="aug",
             )
         else:
@@ -325,6 +328,7 @@ def prepare_data_loaders(cfg, seed: int):
                 test_t,
                 cache_root,
                 seed,
+                cfg.data.img_size,
                 prefix="aug",
             )
         else:
@@ -378,6 +382,7 @@ def get_kfold_loaders(
             base_t,
             cache_root,
             cfg.train.seed,
+            cfg.data.img_size,
             prefix="aug",
         )
     else:
@@ -392,6 +397,7 @@ def get_kfold_loaders(
             base_t,
             cache_root,
             cfg.train.seed,
+            cfg.data.img_size,
             prefix="aug",
         )
     else:

--- a/src/data.py
+++ b/src/data.py
@@ -26,30 +26,14 @@ def _should_use_pin_memory() -> bool:
 
 
 class ImageDataset(Dataset):
-    def __init__(self, csv, path: str, transform: Optional[A.Compose] = None):
+    def __init__(self, csv, path: str, transform: Optional[A.Compose] = None, return_filename: bool = False):
         if isinstance(csv, str):
-            self.df = pd.read_csv(csv).values
+            self.df = pd.read_csv(csv)
         else:
-            self.df = csv.values
+            self.df = csv.copy()
         self.path = path
         self.transform = transform
-
-    def __len__(self) -> int:
-        return len(self.df)
-
-    def __getitem__(self, idx: int):
-        name, target = self.df[idx]
-        img = np.array(Image.open(os.path.join(self.path, name)))
-        if self.transform:
-            img = self.transform(image=img)["image"]
-        return img, target
-
-
-class IndexedImageDataset(Dataset):
-    def __init__(self, df: pd.DataFrame, path: str, transform: Optional[A.Compose] = None):
-        self.df = df
-        self.path = path
-        self.transform = transform
+        self.return_filename = return_filename
 
     def __len__(self) -> int:
         return len(self.df)
@@ -59,7 +43,37 @@ class IndexedImageDataset(Dataset):
         img = np.array(Image.open(os.path.join(self.path, name)))
         if self.transform:
             img = self.transform(image=img)["image"]
+        if self.return_filename:
+            return img, target, name
         return img, target
+
+    def get_filename(self, idx: int) -> str:
+        name, _ = self.df.iloc[idx]
+        return name
+
+
+class IndexedImageDataset(Dataset):
+    def __init__(self, df: pd.DataFrame, path: str, transform: Optional[A.Compose] = None, return_filename: bool = False):
+        self.df = df.reset_index(drop=True)
+        self.path = path
+        self.transform = transform
+        self.return_filename = return_filename
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int):
+        name, target = self.df.iloc[idx]
+        img = np.array(Image.open(os.path.join(self.path, name)))
+        if self.transform:
+            img = self.transform(image=img)["image"]
+        if self.return_filename:
+            return img, target, name
+        return img, target
+
+    def get_filename(self, idx: int) -> str:
+        name, _ = self.df.iloc[idx]
+        return name
 
 
 class AugmentedDataset(Dataset):
@@ -83,6 +97,91 @@ class AugmentedDataset(Dataset):
             return self.base_transform(image=img)["image"], target
         img = self.aug_transform(image=img)["image"]
         return img, target
+
+
+class CachedAugmentedDataset(AugmentedDataset):
+    """AugmentedDataset with disk caching support."""
+
+    def __init__(
+        self,
+        base_dataset: Dataset,
+        num_aug: int,
+        aug_transform: A.Compose,
+        base_transform: A.Compose,
+        cache_root: str,
+        seed: int,
+        prefix: str = "aug",
+    ):
+        super().__init__(base_dataset, num_aug, aug_transform, base_transform)
+        self.cache_dir = os.path.join(cache_root, f"seed_{seed}")
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.prefix = prefix
+
+    def __getitem__(self, idx: int):
+        base_idx = idx % len(self.base_dataset)
+        item = self.base_dataset[base_idx]
+        if len(item) == 3:
+            img, target, name = item
+        else:
+            img, target = item
+            if hasattr(self.base_dataset, "get_filename"):
+                name = self.base_dataset.get_filename(base_idx)
+            else:
+                name = f"{base_idx}.jpg"
+
+        aug_idx = idx // len(self.base_dataset) + 1
+        base_name = os.path.splitext(os.path.basename(name))[0]
+        cache_path = os.path.join(self.cache_dir, f"{base_name}_{self.prefix}_{aug_idx}.pt")
+        if os.path.exists(cache_path):
+            img_tensor = torch.load(cache_path)
+        else:
+            if self.num_aug == 0:
+                img_tensor = self.base_transform(image=img)["image"]
+            else:
+                img_tensor = self.aug_transform(image=img)["image"]
+            torch.save(img_tensor, cache_path)
+            # Save jpg for visual confirmation
+            jpg_path = cache_path.replace(".pt", ".jpg")
+            np_img = (img_tensor.permute(1, 2, 0).cpu().numpy() * 255).clip(0, 255).astype(np.uint8)
+            Image.fromarray(np_img).save(jpg_path)
+        return img_tensor, target, base_idx
+
+
+class CachedTransformDataset(Dataset):
+    """Dataset wrapper applying transform with disk caching."""
+
+    def __init__(self, base_dataset: Dataset, transform: A.Compose, cache_root: str, seed: int, tta_idx: int = 1):
+        self.base_dataset = base_dataset
+        self.transform = transform
+        self.cache_dir = os.path.join(cache_root, f"seed_{seed}")
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.tta_idx = tta_idx
+
+    def __len__(self) -> int:
+        return len(self.base_dataset)
+
+    def __getitem__(self, idx: int):
+        item = self.base_dataset[idx]
+        if len(item) == 3:
+            img, target, name = item
+        else:
+            img, target = item
+            if hasattr(self.base_dataset, "get_filename"):
+                name = self.base_dataset.get_filename(idx)
+            else:
+                name = f"{idx}.jpg"
+
+        base_name = os.path.splitext(os.path.basename(name))[0]
+        cache_path = os.path.join(self.cache_dir, f"{base_name}_tta_{self.tta_idx}.pt")
+        if os.path.exists(cache_path):
+            img_tensor = torch.load(cache_path)
+        else:
+            img_tensor = self.transform(image=img)["image"]
+            torch.save(img_tensor, cache_path)
+            jpg_path = cache_path.replace(".pt", ".jpg")
+            np_img = (img_tensor.permute(1, 2, 0).cpu().numpy() * 255).clip(0, 255).astype(np.uint8)
+            Image.fromarray(np_img).save(jpg_path)
+        return img_tensor, target, idx
 
 
 def _basic_transform(img_size: int) -> A.Compose:
@@ -140,7 +239,7 @@ def prepare_data_loaders(cfg, seed: int):
 
     full_train_df = pd.read_csv(train_csv_path)
 
-    test_dataset = ImageDataset(test_csv_path, test_images_path, transform=test_t)
+    test_dataset = ImageDataset(test_csv_path, test_images_path, transform=test_t, return_filename=True)
     test_loader = DataLoader(
         test_dataset,
         batch_size=batch_size,
@@ -151,6 +250,7 @@ def prepare_data_loaders(cfg, seed: int):
 
     aug_cfg = getattr(cfg, "augment", {})
     strategy = cfg.validation.strategy
+    cache_root = os.path.join(os.path.dirname(train_images_path), "train_cache")
 
     if strategy == "holdout":
         train_df, val_df = _split_holdout(
@@ -159,16 +259,32 @@ def prepare_data_loaders(cfg, seed: int):
             cfg.validation.holdout.stratify,
             seed,
         )
-        train_ds = IndexedImageDataset(train_df, train_images_path, transform=None)
-        val_ds = IndexedImageDataset(val_df, train_images_path, transform=None)
+        train_ds = IndexedImageDataset(train_df, train_images_path, transform=None, return_filename=True)
+        val_ds = IndexedImageDataset(val_df, train_images_path, transform=None, return_filename=True)
         if aug_cfg.get("train_aug_count", 0) > 0:
-            train_ds = AugmentedDataset(train_ds, aug_cfg.get("train_aug_count", 0), train_t, test_t)
+            train_ds = CachedAugmentedDataset(
+                train_ds,
+                aug_cfg.get("train_aug_count", 0),
+                train_t,
+                test_t,
+                cache_root,
+                seed,
+                prefix="aug",
+            )
         else:
-            train_ds = IndexedImageDataset(train_df, train_images_path, transform=train_t)
+            train_ds = IndexedImageDataset(train_df, train_images_path, transform=train_t, return_filename=True)
         if aug_cfg.get("valid_aug_count", 0) > 0:
-            val_ds = AugmentedDataset(val_ds, aug_cfg.get("valid_aug_count", 0), val_t, test_t)
+            val_ds = CachedAugmentedDataset(
+                val_ds,
+                aug_cfg.get("valid_aug_count", 0),
+                val_t,
+                test_t,
+                cache_root,
+                seed,
+                prefix="aug",
+            )
         else:
-            val_ds = IndexedImageDataset(val_df, train_images_path, transform=val_t)
+            val_ds = IndexedImageDataset(val_df, train_images_path, transform=val_t, return_filename=True)
 
         train_loader = DataLoader(
             train_ds,
@@ -196,14 +312,23 @@ def prepare_data_loaders(cfg, seed: int):
             train_t,
             val_t,
             test_t,
+            cache_root,
         )
 
     if strategy == "none":
-        train_ds = IndexedImageDataset(full_train_df, train_images_path, transform=None)
+        train_ds = IndexedImageDataset(full_train_df, train_images_path, transform=None, return_filename=True)
         if aug_cfg.get("train_aug_count", 0) > 0:
-            train_ds = AugmentedDataset(train_ds, aug_cfg.get("train_aug_count", 0), train_t, test_t)
+            train_ds = CachedAugmentedDataset(
+                train_ds,
+                aug_cfg.get("train_aug_count", 0),
+                train_t,
+                test_t,
+                cache_root,
+                seed,
+                prefix="aug",
+            )
         else:
-            train_ds = IndexedImageDataset(full_train_df, train_images_path, transform=train_t)
+            train_ds = IndexedImageDataset(full_train_df, train_images_path, transform=train_t, return_filename=True)
         train_loader = DataLoader(
             train_ds,
             batch_size=batch_size,
@@ -235,6 +360,7 @@ def get_kfold_loaders(
     train_transform: A.Compose,
     val_transform: A.Compose,
     cfg,
+    cache_root: str,
 ):
     train_idx, val_idx = folds[fold_idx]
     train_df = full_train_df.iloc[train_idx]
@@ -243,17 +369,33 @@ def get_kfold_loaders(
     aug_cfg = getattr(cfg, "augment", {})
     base_t = _basic_transform(cfg.data.img_size)
 
-    train_ds = IndexedImageDataset(train_df, train_images_path, transform=None)
+    train_ds = IndexedImageDataset(train_df, train_images_path, transform=None, return_filename=True)
     if aug_cfg.get("train_aug_count", 0) > 0:
-        train_ds = AugmentedDataset(train_ds, aug_cfg.get("train_aug_count", 0), train_transform, base_t)
+        train_ds = CachedAugmentedDataset(
+            train_ds,
+            aug_cfg.get("train_aug_count", 0),
+            train_transform,
+            base_t,
+            cache_root,
+            cfg.train.seed,
+            prefix="aug",
+        )
     else:
-        train_ds = IndexedImageDataset(train_df, train_images_path, transform=train_transform)
+        train_ds = IndexedImageDataset(train_df, train_images_path, transform=train_transform, return_filename=True)
 
-    val_ds = IndexedImageDataset(val_df, train_images_path, transform=None)
+    val_ds = IndexedImageDataset(val_df, train_images_path, transform=None, return_filename=True)
     if aug_cfg.get("valid_aug_count", 0) > 0:
-        val_ds = AugmentedDataset(val_ds, aug_cfg.get("valid_aug_count", 0), val_transform, base_t)
+        val_ds = CachedAugmentedDataset(
+            val_ds,
+            aug_cfg.get("valid_aug_count", 0),
+            val_transform,
+            base_t,
+            cache_root,
+            cfg.train.seed,
+            prefix="aug",
+        )
     else:
-        val_ds = IndexedImageDataset(val_df, train_images_path, transform=val_transform)
+        val_ds = IndexedImageDataset(val_df, train_images_path, transform=val_transform, return_filename=True)
 
     train_loader = DataLoader(
         train_ds,

--- a/src/tests/test_augmentation.py
+++ b/src/tests/test_augmentation.py
@@ -53,9 +53,17 @@ def test_cached_augmented_dataset(tmp_path):
     aug_t = Compose([Resize(32, 32), Normalize(), ToTensorV2()])
     base_t = Compose([Resize(32, 32), Normalize(), ToTensorV2()])
     cache_root = os.path.join(tmp_path, "cache")
-    dataset = CachedAugmentedDataset(base_ds, num_aug=1, aug_transform=aug_t, base_transform=base_t, cache_root=cache_root, seed=42)
+    dataset = CachedAugmentedDataset(
+        base_ds,
+        num_aug=1,
+        aug_transform=aug_t,
+        base_transform=base_t,
+        cache_root=cache_root,
+        seed=42,
+        img_size=32,
+    )
     img, target, idx = dataset[0]
-    cache_file = os.path.join(cache_root, "seed_42", "0_aug_1.pt")
+    cache_file = os.path.join(cache_root, "img32_seed42", "0_aug_1.pt")
     assert os.path.exists(cache_file)
     img2, target2, idx2 = dataset[0]
     assert torch.equal(img, img2)

--- a/src/tests/test_augmentation.py
+++ b/src/tests/test_augmentation.py
@@ -12,7 +12,7 @@ from albumentations.pytorch import ToTensorV2
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from data import ImageDataset, AugmentedDataset, get_transforms
+from data import ImageDataset, AugmentedDataset, CachedAugmentedDataset, get_transforms
 from inference import predict_single_model
 
 
@@ -45,3 +45,17 @@ def test_predict_single_model_tta():
     model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(32 * 32 * 3, 2))
     preds = predict_single_model(model, loader, torch.device("cpu"))
     assert len(preds) == len(dataset)
+
+
+def test_cached_augmented_dataset(tmp_path):
+    df, img_dir = _create_dummy_dataset(tmp_path, 1)
+    base_ds = ImageDataset(df, img_dir, return_filename=True)
+    aug_t = Compose([Resize(32, 32), Normalize(), ToTensorV2()])
+    base_t = Compose([Resize(32, 32), Normalize(), ToTensorV2()])
+    cache_root = os.path.join(tmp_path, "cache")
+    dataset = CachedAugmentedDataset(base_ds, num_aug=1, aug_transform=aug_t, base_transform=base_t, cache_root=cache_root, seed=42)
+    img, target, idx = dataset[0]
+    cache_file = os.path.join(cache_root, "seed_42", "0_aug_1.pt")
+    assert os.path.exists(cache_file)
+    img2, target2, idx2 = dataset[0]
+    assert torch.equal(img, img2)

--- a/src/tests/test_data.py
+++ b/src/tests/test_data.py
@@ -274,7 +274,7 @@ class TestDataLoaderPreparation:
         assert kfold_data is not None
         
         # K-Fold 데이터 확인
-        folds, full_train_df, train_images_path, train_transform, val_transform, test_transform = kfold_data
+        folds, full_train_df, train_images_path, train_transform, val_transform, test_transform, cache_root = kfold_data
         assert len(folds) == 3
         assert len(full_train_df) == 60
         assert train_images_path == os.path.join(self.data_dir, "train")
@@ -364,6 +364,7 @@ class TestKFoldLoaders:
             self.train_transform,
             self.val_transform,
             self.cfg,
+            os.path.join(self.data_dir, "cache"),
         )
         
         # 반환값 확인

--- a/src/tests/test_training.py
+++ b/src/tests/test_training.py
@@ -303,7 +303,7 @@ class TestTrainKFoldModels:
         train_transform = None
         test_transform = None
         
-        self.kfold_data = (folds, full_train_df, data_path, train_transform, test_transform, test_transform)
+        self.kfold_data = (folds, full_train_df, data_path, train_transform, test_transform, test_transform, "/tmp/cache")
     
     @patch('training.get_kfold_loaders')
     @patch('training.log')

--- a/src/training.py
+++ b/src/training.py
@@ -115,8 +115,9 @@ def _predict_probs(model, loader, device):
 def _clone_dataset_with_transform(dataset, transform, cache_info=None, tta_idx=1):
     cache_root = None
     seed = None
+    img_size = None
     if cache_info is not None:
-        cache_root, seed = cache_info
+        cache_root, seed, img_size = cache_info
 
     # AugmentedDataset인 경우 base_dataset을 사용
     if hasattr(dataset, "base_dataset"):
@@ -131,8 +132,8 @@ def _clone_dataset_with_transform(dataset, transform, cache_info=None, tta_idx=1
         else:
             base = IndexedImageDataset(base_dataset.df.copy(), base_dataset.path, transform=None, return_filename=True)
 
-        if cache_root and seed is not None:
-            return CachedTransformDataset(base, transform, cache_root, seed, tta_idx)
+        if cache_root and seed is not None and img_size is not None:
+            return CachedTransformDataset(base, transform, cache_root, seed, img_size, tta_idx)
         return type(base)(base.df, base.path, transform=transform)
 
     raise ValueError("Unsupported dataset type for TTA")

--- a/src/training.py
+++ b/src/training.py
@@ -34,6 +34,7 @@ from data import (
     ImageDataset,
     IndexedImageDataset,
     AugmentedDataset,
+    CachedTransformDataset,
 )
 from models import setup_model_and_optimizer, save_model_with_metadata, get_model_save_path
 from utils import EarlyStopping
@@ -111,19 +112,29 @@ def _predict_probs(model, loader, device):
     return np.concatenate(probs, axis=0)
 
 
-def _clone_dataset_with_transform(dataset, transform):
+def _clone_dataset_with_transform(dataset, transform, cache_info=None, tta_idx=1):
+    cache_root = None
+    seed = None
+    if cache_info is not None:
+        cache_root, seed = cache_info
+
     # AugmentedDataset인 경우 base_dataset을 사용
     if hasattr(dataset, "base_dataset"):
         base_dataset = dataset.base_dataset
-        if hasattr(base_dataset, "df") and hasattr(base_dataset, "path"):
-            return IndexedImageDataset(base_dataset.df.copy(), base_dataset.path, transform=transform)
-    
-    if hasattr(dataset, "df") and hasattr(dataset, "path"):
-        if isinstance(dataset, ImageDataset):
-            df = pd.DataFrame(dataset.df, columns=["ID", "target"])
-            return ImageDataset(df, dataset.path, transform=transform)
-        elif isinstance(dataset, IndexedImageDataset):
-            return IndexedImageDataset(dataset.df.copy(), dataset.path, transform=transform)
+    else:
+        base_dataset = dataset
+
+    if hasattr(base_dataset, "df") and hasattr(base_dataset, "path"):
+        if isinstance(base_dataset, ImageDataset):
+            df = base_dataset.df if isinstance(base_dataset.df, pd.DataFrame) else pd.DataFrame(base_dataset.df, columns=["ID", "target"])
+            base = ImageDataset(df, base_dataset.path, transform=None, return_filename=True)
+        else:
+            base = IndexedImageDataset(base_dataset.df.copy(), base_dataset.path, transform=None, return_filename=True)
+
+        if cache_root and seed is not None:
+            return CachedTransformDataset(base, transform, cache_root, seed, tta_idx)
+        return type(base)(base.df, base.path, transform=transform)
+
     raise ValueError("Unsupported dataset type for TTA")
 
 
@@ -346,7 +357,7 @@ def train_single_model(cfg, train_loader, val_loader, device):
 
 def train_kfold_models(cfg, kfold_data, device):
     """K-Fold 교차 검증 학습"""
-    folds, full_train_df, data_path, train_transform, val_transform, test_transform = kfold_data
+    folds, full_train_df, data_path, train_transform, val_transform, test_transform, cache_root = kfold_data
     n_splits = len(folds)
     models = []
     aug_cfg = getattr(cfg, "augment", {})
@@ -363,6 +374,7 @@ def train_kfold_models(cfg, kfold_data, device):
             train_transform,
             val_transform,
             cfg,
+            cache_root,
         )
         
         # 모델 초기화


### PR DESCRIPTION
## Summary
- implement `CachedAugmentedDataset` and `CachedTransformDataset` for disk-based transform caching
- store augmented images by seed in `train_cache` directory
- support caching in data loaders and inference functions
- update tests for new functionality and add caching test

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccb52e70c8323bd1467947a830dfc