### PR TITLE
Add disk-based model management

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -109,9 +109,7 @@ output:
 
 # Model saving configuration
 model_save:
-  enabled: false
   dir: "models"
-  save_best: false  # 최고 성능 모델 저장
   wandb_artifact: false  # wandb 아티팩트로 등록
 
 # Random seed ensemble configuration

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -112,7 +112,6 @@ model_save:
   enabled: false
   dir: "models"
   save_best: false  # 최고 성능 모델 저장
-  save_last: false  # 마지막 에포크 모델 저장
   wandb_artifact: false  # wandb 아티팩트로 등록
 
 # Random seed ensemble configuration

--- a/src/config/test_new_features.yaml
+++ b/src/config/test_new_features.yaml
@@ -61,9 +61,7 @@ output:
 
 # Model saving configuration
 model_save:
-  enabled: true
   dir: "models"
-  save_best: true
   wandb_artifact: false  # 테스트를 위해 비활성화
 
 # W&B configuration

--- a/src/config/test_new_features.yaml
+++ b/src/config/test_new_features.yaml
@@ -64,7 +64,6 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: false
   wandb_artifact: false  # 테스트를 위해 비활성화
 
 # W&B configuration

--- a/src/config/test_new_features.yaml
+++ b/src/config/test_new_features.yaml
@@ -64,7 +64,7 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: true
+  save_last: false
   wandb_artifact: false  # 테스트를 위해 비활성화
 
 # W&B configuration

--- a/src/config/test_scheduler.yaml
+++ b/src/config/test_scheduler.yaml
@@ -54,7 +54,7 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: true
+  save_last: false
   wandb_artifact: false
 
 # W&B configuration

--- a/src/config/test_scheduler.yaml
+++ b/src/config/test_scheduler.yaml
@@ -54,7 +54,6 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: false
   wandb_artifact: false
 
 # W&B configuration

--- a/src/config/test_scheduler.yaml
+++ b/src/config/test_scheduler.yaml
@@ -51,9 +51,7 @@ output:
 
 # Model saving configuration
 model_save:
-  enabled: true
   dir: "models"
-  save_best: true
   wandb_artifact: false
 
 # W&B configuration

--- a/src/config/test_wandb_artifact.yaml
+++ b/src/config/test_wandb_artifact.yaml
@@ -24,7 +24,7 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: true
+  save_last: false
   wandb_artifact: true  # wandb 아티팩트 등록 활성화
 
 wandb:

--- a/src/config/test_wandb_artifact.yaml
+++ b/src/config/test_wandb_artifact.yaml
@@ -21,9 +21,7 @@ data:
 device: mps
 
 model_save:
-  enabled: true
   dir: "models"
-  save_best: true
   wandb_artifact: true  # wandb 아티팩트 등록 활성화
 
 wandb:

--- a/src/config/test_wandb_artifact.yaml
+++ b/src/config/test_wandb_artifact.yaml
@@ -24,7 +24,6 @@ model_save:
   enabled: true
   dir: "models"
   save_best: true
-  save_last: false
   wandb_artifact: true  # wandb 아티팩트 등록 활성화
 
 wandb:

--- a/src/main.py
+++ b/src/main.py
@@ -133,25 +133,21 @@ def main(cfg: DictConfig) -> None:
         if validation_strategy == "kfold":
             models = train_kfold_models(cfg, kfold_data, device)
             log.info("K-Fold 교차 검증 학습 완료")
-            model_save_cfg = getattr(cfg, "model_save", {})
-            if model_save_cfg.get("enabled", False) and model_save_cfg.get("wandb_artifact", False):
+            if cfg.model_save.wandb_artifact:
                 for fold_idx in range(len(models)):
-                    if model_save_cfg.get("save_best", False):
-                        best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
-                        metadata = {"fold": fold_idx + 1, "type": "best"}
-                        save_model_as_artifact(best_model_path, cfg, f"best_fold{fold_idx + 1}", metadata)
+                    best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
+                    metadata = {"fold": fold_idx + 1, "type": "best"}
+                    save_model_as_artifact(best_model_path, cfg, f"best_fold{fold_idx + 1}", metadata)
             pred_df = run_inference(
                 models, test_loader, test_loader.dataset, cfg, device, is_kfold=True
             )
         else:
             model = train_single_model(cfg, train_loader, val_loader, device)
             log.info("단일 모델 학습 완료")
-            model_save_cfg = getattr(cfg, "model_save", {})
-            if model_save_cfg.get("enabled", False) and model_save_cfg.get("wandb_artifact", False):
-                if model_save_cfg.get("save_best", False):
-                    best_model_path = get_model_save_path(cfg, "best")
-                    metadata = {"type": "best"}
-                    save_model_as_artifact(best_model_path, cfg, "best", metadata)
+            if cfg.model_save.wandb_artifact:
+                best_model_path = get_model_save_path(cfg, "best")
+                metadata = {"type": "best"}
+                save_model_as_artifact(best_model_path, cfg, "best", metadata)
             pred_df = run_inference(
                 model, test_loader, test_loader.dataset, cfg, device, is_kfold=False
             )

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,6 @@ from augment import get_tta_transforms
 from data import get_transforms
 import numpy as np
 from models import (
-    get_model_save_path,
     get_seed_fold_model_path,
     load_model_for_inference,
 )
@@ -135,7 +134,7 @@ def main(cfg: DictConfig) -> None:
             log.info("K-Fold 교차 검증 학습 완료")
             if cfg.model_save.wandb_artifact:
                 for fold_idx in range(len(models)):
-                    best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
+                    best_model_path = get_seed_fold_model_path(cfg, cfg.train.seed, fold_idx + 1)
                     metadata = {"fold": fold_idx + 1, "type": "best"}
                     save_model_as_artifact(best_model_path, cfg, f"best_fold{fold_idx + 1}", metadata)
             pred_df = run_inference(
@@ -145,8 +144,8 @@ def main(cfg: DictConfig) -> None:
             model = train_single_model(cfg, train_loader, val_loader, device)
             log.info("단일 모델 학습 완료")
             if cfg.model_save.wandb_artifact:
-                best_model_path = get_model_save_path(cfg, "best")
-                metadata = {"type": "best"}
+                best_model_path = get_seed_fold_model_path(cfg, cfg.train.seed, 0)
+                metadata = {"fold": 0, "type": "best"}
                 save_model_as_artifact(best_model_path, cfg, "best", metadata)
             pred_df = run_inference(
                 model, test_loader, test_loader.dataset, cfg, device, is_kfold=False

--- a/src/main.py
+++ b/src/main.py
@@ -140,10 +140,6 @@ def main(cfg: DictConfig) -> None:
                         best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
                         metadata = {"fold": fold_idx + 1, "type": "best"}
                         save_model_as_artifact(best_model_path, cfg, f"best_fold{fold_idx + 1}", metadata)
-                    if model_save_cfg.get("save_last", False):
-                        last_model_path = get_model_save_path(cfg, f"last_fold{fold_idx + 1}")
-                        metadata = {"fold": fold_idx + 1, "type": "last"}
-                        save_model_as_artifact(last_model_path, cfg, f"last_fold{fold_idx + 1}", metadata)
             pred_df = run_inference(
                 models, test_loader, test_loader.dataset, cfg, device, is_kfold=True
             )
@@ -156,10 +152,6 @@ def main(cfg: DictConfig) -> None:
                     best_model_path = get_model_save_path(cfg, "best")
                     metadata = {"type": "best"}
                     save_model_as_artifact(best_model_path, cfg, "best", metadata)
-                if model_save_cfg.get("save_last", False):
-                    last_model_path = get_model_save_path(cfg, "last")
-                    metadata = {"type": "last"}
-                    save_model_as_artifact(last_model_path, cfg, "last", metadata)
             pred_df = run_inference(
                 model, test_loader, test_loader.dataset, cfg, device, is_kfold=False
             )

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@
 """
 
 import os
+import torch
 import hydra
 from omegaconf import DictConfig, OmegaConf
 from dotenv import load_dotenv
@@ -25,7 +26,11 @@ from inference import (
 from augment import get_tta_transforms
 from data import get_transforms
 import numpy as np
-from models import get_model_save_path
+from models import (
+    get_model_save_path,
+    get_seed_fold_model_path,
+    load_model_for_inference,
+)
 
 
 # 현재 스크립트 위치를 작업 디렉토리로 설정
@@ -62,7 +67,7 @@ def main(cfg: DictConfig) -> None:
     seed_ensemble_cfg = getattr(cfg, "random_seed_ensemble", {"enabled": False})
     if seed_ensemble_cfg.get("enabled", False):
         ensemble_count = int(seed_ensemble_cfg.get("count", 1))
-        all_probs = []
+        model_paths: list[str] = []
         for idx in range(ensemble_count):
             current_seed = cfg.train.seed + idx
             log.info(f"=== Random seed ensemble {idx + 1}/{ensemble_count} - seed {current_seed} ===")
@@ -73,55 +78,34 @@ def main(cfg: DictConfig) -> None:
             validation_strategy = cfg.validation.strategy
 
             if validation_strategy == "kfold":
-                models = train_kfold_models(cfg, kfold_data, device)
-                model_save_cfg = getattr(cfg, "model_save", {})
-                if model_save_cfg.get("enabled", False) and model_save_cfg.get("wandb_artifact", False):
-                    for fold_idx in range(len(models)):
-                        if model_save_cfg.get("save_best", False):
-                            best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}_seed{idx}")
-                            metadata = {"fold": fold_idx + 1, "type": "best", "seed": current_seed}
-                            save_model_as_artifact(best_model_path, cfg, f"best_fold{fold_idx + 1}_seed{idx}", metadata)
-                        if model_save_cfg.get("save_last", False):
-                            last_model_path = get_model_save_path(cfg, f"last_fold{fold_idx + 1}_seed{idx}")
-                            metadata = {"fold": fold_idx + 1, "type": "last", "seed": current_seed}
-                            save_model_as_artifact(last_model_path, cfg, f"last_fold{fold_idx + 1}_seed{idx}", metadata)
-                tta_transforms = None
-                aug_cfg = getattr(cfg, "augment", {})
-                if aug_cfg.get("test_tta_enabled", True):
-                    tta_transforms = get_tta_transforms(cfg.data.img_size)
-                probs = predict_kfold_ensemble(
-                    models,
-                    test_loader,
-                    device,
-                    tta_transforms=tta_transforms,
-                    return_probs=True,
-                )
+                items = train_kfold_models(cfg, kfold_data, device, save_to_disk=True, seed=current_seed)
+                model_paths.extend(items)
             else:
-                model = train_single_model(cfg, train_loader, val_loader, device)
-                model_save_cfg = getattr(cfg, "model_save", {})
-                if model_save_cfg.get("enabled", False) and model_save_cfg.get("wandb_artifact", False):
-                    if model_save_cfg.get("save_best", False):
-                        best_model_path = get_model_save_path(cfg, f"best_seed{idx}")
-                        metadata = {"type": "best", "seed": current_seed}
-                        save_model_as_artifact(best_model_path, cfg, f"best_seed{idx}", metadata)
-                    if model_save_cfg.get("save_last", False):
-                        last_model_path = get_model_save_path(cfg, f"last_seed{idx}")
-                        metadata = {"type": "last", "seed": current_seed}
-                        save_model_as_artifact(last_model_path, cfg, f"last_seed{idx}", metadata)
+                item = train_single_model(cfg, train_loader, val_loader, device, save_to_disk=True, seed=current_seed)
+                model_paths.append(item)
 
-                tta_transforms = None
-                aug_cfg = getattr(cfg, "augment", {})
-                if aug_cfg.get("test_tta_enabled", True):
-                    tta_transforms = get_tta_transforms(cfg.data.img_size)
-                probs = predict_single_model(
-                    model,
-                    test_loader,
-                    device,
-                    tta_transforms=tta_transforms,
-                    return_probs=True,
-                )
+        # Load saved models and ensemble predictions
+        aug_cfg = getattr(cfg, "augment", {})
+        tta_transforms = None
+        if aug_cfg.get("test_tta_enabled", True):
+            tta_transforms = get_tta_transforms(cfg.data.img_size)
 
+        all_probs = []
+        for item in model_paths:
+            if isinstance(item, str):
+                model = load_model_for_inference(cfg, item, device)
+            else:
+                model = item
+            probs = predict_single_model(
+                model,
+                test_loader,
+                device,
+                tta_transforms=tta_transforms,
+                return_probs=True,
+            )
             all_probs.append(probs)
+            del model
+            torch.cuda.empty_cache()
 
         ensemble_probs = np.mean(all_probs, axis=0)
         final_preds = ensemble_probs.argmax(axis=1)

--- a/src/models.py
+++ b/src/models.py
@@ -229,7 +229,13 @@ def get_seed_fold_model_path(cfg, seed: int, fold: int) -> str:
     model_dir = getattr(cfg, "model_save", {}).get("dir", "models")
     os.makedirs(model_dir, exist_ok=True)
     model_name = cfg.model.name
-    filename = f"{model_name}_seed{seed}_fold{fold}.pth"
+    
+    # K-fold인 경우 fold 번호 포함, Holdout인 경우 seed만 사용
+    if fold == 0:  # Holdout
+        filename = f"{model_name}_seed{seed}.pth"
+    else:  # K-fold (fold는 1, 2, 3, ...)
+        filename = f"{model_name}_seed{seed}_fold{fold}.pth"
+    
     return os.path.join(model_dir, filename)
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -214,16 +214,14 @@ def load_model_with_metadata(model, path):
 
 def get_model_save_path(cfg, model_type):
     """모델 저장 경로 생성"""
-    if cfg.model_save.enabled:
-        model_dir = cfg.model_save.dir
-        os.makedirs(model_dir, exist_ok=True)
-        
-        # 모델 파일명 생성
-        model_name = cfg.model.name
-        filename = f"{model_name}_{model_type}.pth"
-        return os.path.join(model_dir, filename)
-    else:
-        return None
+    model_dir = cfg.model_save.dir
+    os.makedirs(model_dir, exist_ok=True)
+
+    # 모델 파일명 생성
+    model_name = cfg.model.name
+    seed = getattr(cfg.train, "seed", 0)
+    filename = f"{model_name}_seed{seed}_{model_type}.pth"
+    return os.path.join(model_dir, filename)
 
 
 def get_seed_fold_model_path(cfg, seed: int, fold: int) -> str:

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -107,6 +107,10 @@ class TestMainPipeline:
                 'dir': self.output_dir,
                 'filename': 'test_predictions.csv'
             },
+            'model_save': {
+                'dir': os.path.join(self.temp_dir, 'models'),
+                'wandb_artifact': False
+            },
             'wandb': {
                 'enabled': False
             }
@@ -155,6 +159,9 @@ device: cpu
 output:
   dir: {self.output_dir}
   filename: test_predictions.csv
+model_save:
+  dir: {os.path.join(self.temp_dir, "models")}
+  wandb_artifact: false
 wandb:
   enabled: false
 """)
@@ -358,6 +365,10 @@ class TestModuleIntegration:
                 'dir': self.temp_dir,
                 'filename': 'integration_test.csv'
             },
+            'model_save': {
+                'dir': os.path.join(self.temp_dir, 'models'),
+                'wandb_artifact': False
+            },
             'wandb': {
                 'enabled': False
             }
@@ -525,7 +536,8 @@ class TestErrorHandling:
                 'num_workers': 0
             },
             'train': {'batch_size': 4, 'seed': 42},
-            'validation': {'strategy': 'holdout'}
+            'validation': {'strategy': 'holdout'},
+            'model_save': {'dir': os.path.join(temp_dir, 'models')}
         })
         
         with pytest.raises(FileNotFoundError):

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -267,8 +267,10 @@ class TestModelSaveLoad:
             'model': {
                 'name': 'resnet18'
             },
+            'train': {
+                'seed': 123
+            },
             'model_save': {
-                'enabled': True,
                 'dir': self.temp_dir
             }
         })
@@ -278,24 +280,9 @@ class TestModelSaveLoad:
         
         assert best_path is not None
         assert last_path is not None
-        assert "resnet18_best.pth" in best_path
-        assert "resnet18_last.pth" in last_path
+        assert "resnet18_seed123_best.pth" in best_path
+        assert "resnet18_seed123_last.pth" in last_path
     
-    def test_get_model_save_path_disabled(self):
-        """모델 저장 비활성화 테스트"""
-        cfg = OmegaConf.create({
-            'model': {
-                'name': 'resnet18'
-            },
-            'model_save': {
-                'enabled': False,
-                'dir': self.temp_dir
-            }
-        })
-
-        path = get_model_save_path(cfg, "best")
-        assert path is None
-
 
 class TestSeedFoldPath:
     """시드 및 폴드 기반 경로 생성 및 로드 테스트"""
@@ -309,7 +296,7 @@ class TestSeedFoldPath:
     def test_get_seed_fold_model_path(self):
         cfg = OmegaConf.create({
             'model': {'name': 'resnet18'},
-            'model_save': {'enabled': True, 'dir': self.temp_dir}
+            'model_save': {'dir': self.temp_dir}
         })
 
         path = get_seed_fold_model_path(cfg, seed=1, fold=2)
@@ -319,7 +306,7 @@ class TestSeedFoldPath:
     def test_load_model_for_inference(self):
         cfg = OmegaConf.create({
             'model': {'name': 'resnet18', 'num_classes': 3},
-            'model_save': {'enabled': True, 'dir': self.temp_dir}
+            'model_save': {'dir': self.temp_dir}
         })
 
         model = create_model('resnet18', pretrained=False, num_classes=3)

--- a/src/tests/test_training.py
+++ b/src/tests/test_training.py
@@ -214,6 +214,10 @@ class TestTrainSingleModel:
             'wandb': {
                 'enabled': False
             }
+            ,
+            'model_save': {
+                'dir': 'models'
+            }
         })
     
     @patch('training.log')
@@ -280,6 +284,9 @@ class TestTrainKFoldModels:
                 'early_stopping': {
                     'enabled': False
                 }
+            },
+            'model_save': {
+                'dir': 'models'
             },
             'wandb': {
                 'enabled': False
@@ -528,7 +535,7 @@ class TestMixedPrecisionTraining:
                 }
             },
             'model_save': {
-                'enabled': False
+                'dir': 'models'
             },
             'wandb': {
                 'enabled': False
@@ -588,7 +595,7 @@ class TestMixedPrecisionTraining:
                 }
             },
             'model_save': {
-                'enabled': False
+                'dir': 'models'
             },
             'wandb': {
                 'enabled': False

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -195,7 +195,7 @@ class TestSetupWandb:
             },
             'device': 'cpu',
             'output': {'dir': 'out', 'filename': 'pred.csv'},
-            'model_save': {'enabled': False},
+            'model_save': {'dir': 'models'},
             'random_seed_ensemble': {'enabled': False, 'count': 1}
         })
         
@@ -277,7 +277,7 @@ class TestSetupWandb:
             },
             'device': 'cpu',
             'output': {'dir': 'out', 'filename': 'pred.csv'},
-            'model_save': {'enabled': False},
+            'model_save': {'dir': 'models'},
             'random_seed_ensemble': {'enabled': False, 'count': 1}
         })
         

--- a/src/training.py
+++ b/src/training.py
@@ -290,17 +290,15 @@ def train_single_model(cfg, train_loader, val_loader, device, save_to_disk: bool
                 best_epoch = epoch + 1
 
                 # 최고 성능 모델 저장
-                model_save_cfg = getattr(cfg, "model_save", {})
-                if model_save_cfg.get("enabled", False) and model_save_cfg.get("save_best", False):
-                    best_model_path = get_model_save_path(cfg, "best")
-                    metadata = {
-                        "epoch": best_epoch,
-                        "val_f1": best_metric,
-                        "val_acc": ret['val_acc'],
-                        "val_loss": ret['val_loss'],
-                        "model_name": cfg.model.name
-                    }
-                    save_model_with_metadata(model, best_model_path, metadata)
+                best_model_path = get_model_save_path(cfg, "best")
+                metadata = {
+                    "epoch": best_epoch,
+                    "val_f1": best_metric,
+                    "val_acc": ret['val_acc'],
+                    "val_loss": ret['val_loss'],
+                    "model_name": cfg.model.name,
+                }
+                save_model_with_metadata(model, best_model_path, metadata)
                 if save_to_disk and save_path is not None:
                     disk_metadata = {
                         "epoch": best_epoch,
@@ -463,18 +461,16 @@ def train_kfold_models(cfg, kfold_data, device, save_to_disk: bool = False, seed
                 best_epoch = epoch + 1
 
                 # 최고 성능 모델 저장
-                model_save_cfg = getattr(cfg, "model_save", {})
-                if model_save_cfg.get("enabled", False) and model_save_cfg.get("save_best", False):
-                    best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
-                    metadata = {
-                        "fold": fold_idx + 1,
-                        "epoch": best_epoch,
-                        "val_f1": best_metric,
-                        "val_acc": ret['val_acc'],
-                        "val_loss": ret['val_loss'],
-                        "model_name": cfg.model.name
-                    }
-                    save_model_with_metadata(model, best_model_path, metadata)
+                best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
+                metadata = {
+                    "fold": fold_idx + 1,
+                    "epoch": best_epoch,
+                    "val_f1": best_metric,
+                    "val_acc": ret['val_acc'],
+                    "val_loss": ret['val_loss'],
+                    "model_name": cfg.model.name,
+                }
+                save_model_with_metadata(model, best_model_path, metadata)
                 if save_to_disk and disk_path is not None:
                     disk_metadata = {
                         "fold": fold_idx + 1,

--- a/src/training.py
+++ b/src/training.py
@@ -300,14 +300,7 @@ def train_single_model(cfg, train_loader, val_loader, device, save_to_disk: bool
                 }
                 save_model_with_metadata(model, best_model_path, metadata)
                 if save_to_disk and save_path is not None:
-                    disk_metadata = {
-                        "epoch": best_epoch,
-                        "val_f1": best_metric,
-                        "val_acc": ret['val_acc'],
-                        "val_loss": ret['val_loss'],
-                        "model_name": cfg.model.name,
-                    }
-                    save_model_with_metadata(model, save_path, disk_metadata)
+                    save_model_with_metadata(model, save_path, metadata)
         else:
             # No validation
             log_message = f"Epoch {epoch+1}/{cfg.train.epochs} 완료 - "
@@ -472,15 +465,7 @@ def train_kfold_models(cfg, kfold_data, device, save_to_disk: bool = False, seed
                 }
                 save_model_with_metadata(model, best_model_path, metadata)
                 if save_to_disk and disk_path is not None:
-                    disk_metadata = {
-                        "fold": fold_idx + 1,
-                        "epoch": best_epoch,
-                        "val_f1": best_metric,
-                        "val_acc": ret['val_acc'],
-                        "val_loss": ret['val_loss'],
-                        "model_name": cfg.model.name,
-                    }
-                    save_model_with_metadata(model, disk_path, disk_metadata)
+                    save_model_with_metadata(model, disk_path, metadata)
             
             # Early stopping 체크
             if early_stopping is not None:

--- a/src/training.py
+++ b/src/training.py
@@ -39,7 +39,6 @@ from data import (
 from models import (
     setup_model_and_optimizer,
     save_model_with_metadata,
-    get_model_save_path,
     get_seed_fold_model_path,
 )
 from utils import EarlyStopping
@@ -289,17 +288,16 @@ def train_single_model(cfg, train_loader, val_loader, device, save_to_disk: bool
                 best_metric = ret['val_f1']
                 best_epoch = epoch + 1
 
-                # 최고 성능 모델 저장
-                best_model_path = get_model_save_path(cfg, "best")
-                metadata = {
-                    "epoch": best_epoch,
-                    "val_f1": best_metric,
-                    "val_acc": ret['val_acc'],
-                    "val_loss": ret['val_loss'],
-                    "model_name": cfg.model.name,
-                }
-                save_model_with_metadata(model, best_model_path, metadata)
+                # 최고 성능 모델 저장 (fold 정보 포함)
                 if save_to_disk and save_path is not None:
+                    metadata = {
+                        "fold": fold,
+                        "epoch": best_epoch,
+                        "val_f1": best_metric,
+                        "val_acc": ret['val_acc'],
+                        "val_loss": ret['val_loss'],
+                        "model_name": cfg.model.name,
+                    }
                     save_model_with_metadata(model, save_path, metadata)
         else:
             # No validation
@@ -453,18 +451,16 @@ def train_kfold_models(cfg, kfold_data, device, save_to_disk: bool = False, seed
                 best_metric = ret['val_f1']
                 best_epoch = epoch + 1
 
-                # 최고 성능 모델 저장
-                best_model_path = get_model_save_path(cfg, f"best_fold{fold_idx + 1}")
-                metadata = {
-                    "fold": fold_idx + 1,
-                    "epoch": best_epoch,
-                    "val_f1": best_metric,
-                    "val_acc": ret['val_acc'],
-                    "val_loss": ret['val_loss'],
-                    "model_name": cfg.model.name,
-                }
-                save_model_with_metadata(model, best_model_path, metadata)
+                # 최고 성능 모델 저장 (fold 정보 포함)
                 if save_to_disk and disk_path is not None:
+                    metadata = {
+                        "fold": fold_idx + 1,
+                        "epoch": best_epoch,
+                        "val_f1": best_metric,
+                        "val_acc": ret['val_acc'],
+                        "val_loss": ret['val_loss'],
+                        "model_name": cfg.model.name,
+                    }
                     save_model_with_metadata(model, disk_path, metadata)
             
             # Early stopping 체크

--- a/src/utils.py
+++ b/src/utils.py
@@ -148,7 +148,6 @@ def setup_wandb(cfg):
             "model_save_enabled": cfg.model_save.enabled,
             # "model_save_dir": cfg.model_save.dir,
             # "model_save_save_best": cfg.model_save.save_best,
-            # "model_save_save_last": cfg.model_save.save_last,
             # "model_save_wandb_artifact": cfg.model_save.wandb_artifact,
             
             # Random seed ensemble configuration

--- a/src/utils.py
+++ b/src/utils.py
@@ -145,9 +145,7 @@ def setup_wandb(cfg):
             "output_filename": cfg.output.filename,
             
             # Model saving configuration
-            "model_save_enabled": cfg.model_save.enabled,
             # "model_save_dir": cfg.model_save.dir,
-            # "model_save_save_best": cfg.model_save.save_best,
             # "model_save_wandb_artifact": cfg.model_save.wandb_artifact,
             
             # Random seed ensemble configuration


### PR DESCRIPTION
## Summary
- manage models on disk to prevent OOM
- load saved models at inference time
- support seed/fold specific model paths
- update tests to cover new helpers

## Testing
- `uv run pytest -q`
- `uv run python src/main.py --config-name=fast_test` *(fails: FileNotFoundError for dataset)*

------
https://chatgpt.com/codex/tasks/task_e_686ccc25f8148323af889ac2a2123d53